### PR TITLE
SuperiorLab: Add global varient name for Raphael

### DIFF
--- a/res/values-cs/superior_strings.xml
+++ b/res/values-cs/superior_strings.xml
@@ -74,7 +74,7 @@
     <string name="device_spes_description">spes | Daniel Enweazu</string>
     <string name="device_sweet">Redmi Note 10 Pro</string>
     <string name="device_sweet_description">sweet | Unsatifsed27</string>
-    <string name="device_raphael">Redmi K20 Pro</string>
+    <string name="device_raphael">Redmi K20 Pro/Mi 9T Pro</string>
     <string name="device_raphael_description">raphael | Anirban</string>
     <string name="device_RMX3461">Realme 9 SE 5G</string>
     <string name="device_RMX3461_description">RMX3461 | ZirgomHaidar</string>

--- a/res/values-in/superior_strings.xml
+++ b/res/values-in/superior_strings.xml
@@ -74,7 +74,7 @@
     <string name="device_spes_description">spes | Daniel Enweazu</string>
     <string name="device_sweet">Redmi Note 10 Pro</string>
     <string name="device_sweet_description">sweet | Unsatifsed27</string>
-    <string name="device_raphael">Redmi K20 Pro</string>
+    <string name="device_raphael">Redmi K20 Pro/Mi 9T Pro</string>
     <string name="device_raphael_description">raphael | Anirban</string>
     <string name="device_RMX3461">Realme 9 SE 5G</string>
     <string name="device_RMX3461_description">RMX3461 | ZirgomHaidar</string>

--- a/res/values-ro/superior_strings.xml
+++ b/res/values-ro/superior_strings.xml
@@ -74,7 +74,7 @@
     <string name="device_spes_description">spes | Daniel Enweazu</string>
     <string name="device_sweet">Redmi Note 10 Pro</string>
     <string name="device_sweet_description">sweet | Unsatifsed27</string>
-    <string name="device_raphael">Redmi K20 Pro</string>
+    <string name="device_raphael">Redmi K20 Pro/Mi 9T Pro</string>
     <string name="device_raphael_description">raphael | Anirban</string>
     <string name="device_RMX3461">Realme 9 SE 5G</string>
     <string name="device_RMX3461_description">RMX3461 | ZirgomHaidar</string>

--- a/res/values-ru/superior_strings.xml
+++ b/res/values-ru/superior_strings.xml
@@ -74,7 +74,7 @@
     <string name="device_spes_description">spes | Daniel Enweazu</string>
     <string name="device_sweet">Redmi Note 10 Pro</string>
     <string name="device_sweet_description">sweet | Unsatifsed27</string>
-    <string name="device_raphael">Redmi K20 Pro</string>
+    <string name="device_raphael">Redmi K20 Pro/Mi 9T Pro</string>
     <string name="device_raphael_description">raphael | Anirban</string>
     <string name="device_RMX3461">Реалм 9 SE 5G</string>
     <string name="device_RMX3461_description">RMX3461 | ZirgomHaidar</string>

--- a/res/values-tr/superior_strings.xml
+++ b/res/values-tr/superior_strings.xml
@@ -74,7 +74,7 @@
     <string name="device_spes_description">spes | Daniel Enweazu</string>
     <string name="device_sweet">Redmi Note 10 Pro</string>
     <string name="device_sweet_description">sweet | Unsatifsed27</string>
-    <string name="device_raphael">Redmi K20 Pro</string>
+    <string name="device_raphael">Redmi K20 Pro/Mi 9T Pro</string>
     <string name="device_raphael_description">raphael | Anirban</string>
     <string name="device_RMX3461">Realme 9 SE 5G</string>
     <string name="device_RMX3461_description">RMX3461 | ZirgomHaidar</string>

--- a/res/values/superior_strings.xml
+++ b/res/values/superior_strings.xml
@@ -84,7 +84,7 @@
     <string name="device_spes_description">spes | Daniel Enweazu</string>
     <string name="device_sweet">Redmi Note 10 Pro</string>
     <string name="device_sweet_description">sweet | Unsatifsed27</string>
-    <string name="device_raphael">Redmi K20 Pro</string>
+    <string name="device_raphael">Redmi K20 Pro/Mi 9T Pro</string>
     <string name="device_raphael_description">raphael | Anirban</string>
     <string name="device_RMX3461">Realme 9 SE 5G</string>
     <string name="device_RMX3461_description">RMX3461 | ZirgomHaidar</string>


### PR DESCRIPTION
Besides Redmi K20 Pro, Raphael has a global that goes by Mi 9T Pro .